### PR TITLE
Fixed timeline height

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -368,7 +368,7 @@ time {
 
 main {
 	display: flex;
-	max-width: 47rem;
+	max-width: 55rem;
 	margin: -5rem auto 0;
 	padding: 2.4rem 2rem;
 	flex-direction: column;
@@ -469,6 +469,7 @@ color: #333;
     padding: 10px 10px 10px 35px;
     color: var(--main-text-color);
     -webkit-appearance: none;
+    appearance: none;
     background-color: rgba(128, 128, 128, 0.1);
     border: 1px solid rgba(128, 128, 128, 0.1);
     &::-webkit-input-placeholder {
@@ -563,37 +564,46 @@ color: #333;
 
   // ------------------------------------
 $link-color: var(--link-color);
-
-
 .timeline {
-  position: center;
+  position: relative;
   width: 650px;
   margin: -6em auto;
   padding: 1px;
   list-style-type: none;
-  @media(max-width: 860px) {
+  height: 100%;
+
+  @media (max-width: 860px) {
     width: 100%;
+    margin: 0 auto;
+    /* Add margin to center the timeline on mobile */
   }
+
   &:before {
     position: absolute;
     left: 50%;
+    /* Center the vertical line */
     top: 0;
     content: ' ';
     display: block;
     width: 6px;
     height: 100%;
-    margin-left: -3px;
+    margin-left: -6px;
     background: var(--light-text-color);
     z-index: 5;
-    @media(max-width: 375px) {
-      height: 150%;
+
+    @media (max-width: 860px) {
+      width: 3px;
+      margin-left: -3px;
     }
   }
+
   li {
     padding: 2em 0;
-    @media(max-width: 860px) {
+
+    @media (max-width: 860px) {
       padding: 2em 0;
     }
+
     &::after {
       content: "";
       display: block;
@@ -603,7 +613,6 @@ $link-color: var(--link-color);
     }
   }
 }
-
 
 .direction-l {
   position: relative;


### PR DESCRIPTION
Small changes to `main.scss` to allow the timeline's vertical line to not overflow under the social media icons at high resolutions.

I also slightly widened the page's max-width as a personal preference, this is not intended to be part of the pull request, so revert it before merge.